### PR TITLE
More Accurate Double Spend Test Fleshed Out, Still Not Working 

### DIFF
--- a/lab/double-spend.js
+++ b/lab/double-spend.js
@@ -29,8 +29,8 @@ function fund(node) {
 function spend(node) {
     var web3 = node.getWeb3();
     return new Promise(function (resolve, reject) {
-        console.log(web3.eth.getBalance(web3.eth.accounts[1]), "account 1 balance");
         var send = function () {
+            console.log(web3.eth.getBalance(web3.eth.accounts[1]), "account 1 balance");
             web3.personal.unlockAccount(web3.eth.accounts[1]);
             web3.eth.sendTransaction({
                 from: web3.eth.accounts[1],
@@ -47,7 +47,7 @@ function spend(node) {
                 }
             });
         };
-        setTimeout(send, 1000);
+        setTimeout(send, 15000);
     })
         .then(function (result) { return console.log(web3.eth.getTransaction(result)); });
 }

--- a/lab/double-spend.js
+++ b/lab/double-spend.js
@@ -1,8 +1,8 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var _1 = require("./");
-function fund(client) {
-    var web3 = client;
+function fund(node) {
+    var web3 = node.getWeb3();
     return new Promise(function (resolve, reject) {
         console.log(web3.eth.getBalance(web3.eth.coinbase).toNumber(), "I AM THE COINBASE BALANCE");
         web3.personal.unlockAccount(web3.eth.coinbase);
@@ -15,35 +15,34 @@ function fund(client) {
 }
 function spend(node) {
     var web3 = node.getWeb3();
-    fund(web3).then(function () {
-        return new Promise(function (resolve, reject) {
-            var send = function () {
-                web3.personal.unlockAccount(web3.eth.accounts[1]);
-                web3.eth.sendTransaction({
-                    from: web3.eth.accounts[1],
-                    to: web3.eth.accounts[2],
-                    value: web3.toWei(18)
-                }, function (err, tx) {
-                    if (err) {
-                        console.log(err);
-                        reject(err);
-                    }
-                    else {
-                        console.log(tx);
-                        resolve(tx);
-                    }
-                });
-            };
-            setTimeout(send, 10000);
-        })
-            .then(function (result) { return console.log(web3.eth.getTransaction(result)); });
-    });
+    return new Promise(function (resolve, reject) {
+        var send = function () {
+            web3.personal.unlockAccount(web3.eth.accounts[1]);
+            web3.eth.sendTransaction({
+                from: web3.eth.accounts[1],
+                to: web3.eth.accounts[2],
+                value: web3.toWei(18)
+            }, function (err, tx) {
+                if (err) {
+                    console.log(err);
+                    reject(err);
+                }
+                else {
+                    console.log(tx);
+                    resolve(tx);
+                }
+            });
+        };
+        setTimeout(send, 10000);
+    })
+        .then(function (result) { return console.log(web3.eth.getTransaction(result)); });
 }
 function doubleSpend(config) {
     var node1 = new _1.GethNode(config);
     var node2 = new _1.GethNode(config);
-    node1.start(8546).then(function () { return spend(node1); })
-        .then(function () { return _1.mine(node2, 8547, 9000).then(function () { return node2.start(8546); }).then(function () { return spend(node2); }); });
+    node1.start(8546).then(function () { return fund(node1); }).then(function () { return spend(node1); })
+        .then(function () { return _1.mine(node2, 8547, 19000).then(function () { return fund(node2); })
+        .then(function () { return node2.start(8546); }).then(function () { return spend(node2); }); });
 }
 exports.doubleSpend = doubleSpend;
 //# sourceMappingURL=double-spend.js.map

--- a/lab/double-spend.js
+++ b/lab/double-spend.js
@@ -26,9 +26,10 @@ function fund(node) {
     })
         .then(function (result) { return console.log(web3.eth.getTransaction(result)); });
 }
-function spend(node) {
+function spend(node, miner) {
     var web3 = node.getWeb3();
     return new Promise(function (resolve, reject) {
+        _1.mine(miner, 8547, 30000);
         var send = function () {
             console.log(web3.eth.getBalance(web3.eth.accounts[1]), "account 1 balance");
             web3.personal.unlockAccount(web3.eth.accounts[1]);
@@ -54,9 +55,9 @@ function spend(node) {
 function doubleSpend(config) {
     var node1 = new _1.GethNode(config);
     var node2 = new _1.GethNode(config);
-    _1.mine(node1, 8546, 30000).then(function () { return node1.start(8546).then(function () { return fund(node1); }).then(function () { return spend(node1); })
-        .then(function () { return _1.mine(node2, 8547, 30000).then(function () { return node2.start(8546); })
-        .then(function () { return fund(node2); }).then(function () { return spend(node2); }); }); });
+    _1.mine(node1, 8546, 30000).then(function () { return node1.start(8546).then(function () { return fund(node1); }).then(function () { return spend(node1, node2); })
+        .then(function () { return node2.start(8546); })
+        .then(function () { return fund(node2); }).then(function () { return spend(node2); }); });
 }
 exports.doubleSpend = doubleSpend;
 //# sourceMappingURL=double-spend.js.map

--- a/lab/double-spend.js
+++ b/lab/double-spend.js
@@ -4,12 +4,13 @@ var _1 = require("./");
 function fund(node) {
     var web3 = node.getWeb3();
     return new Promise(function (resolve, reject) {
+        console.log(web3.eth.getBalance(web3.eth.coinbase), "coinbase balance");
         var send = function () {
             web3.personal.unlockAccount(web3.eth.coinbase);
             web3.eth.sendTransaction({
                 from: web3.eth.coinbase,
                 to: web3.eth.accounts[1],
-                value: web3.toWei(35)
+                value: web3.toWei(8)
             }, function (err, tx) {
                 if (err) {
                     console.log(err);
@@ -21,19 +22,20 @@ function fund(node) {
                 }
             });
         };
-        setTimeout(fund, 10000);
+        setTimeout(send, 10000);
     })
         .then(function (result) { return console.log(web3.eth.getTransaction(result)); });
 }
 function spend(node) {
     var web3 = node.getWeb3();
     return new Promise(function (resolve, reject) {
+        console.log(web3.eth.getBalance(web3.eth.accounts[1]), "account 1 balance");
         var send = function () {
             web3.personal.unlockAccount(web3.eth.accounts[1]);
             web3.eth.sendTransaction({
                 from: web3.eth.accounts[1],
                 to: web3.eth.accounts[2],
-                value: web3.toWei(18)
+                value: web3.toWei(5)
             }, function (err, tx) {
                 if (err) {
                     console.log(err);

--- a/lab/double-spend.js
+++ b/lab/double-spend.js
@@ -22,7 +22,7 @@ function fund(node) {
                 }
             });
         };
-        setTimeout(send, 10000);
+        setTimeout(send, 1000);
     })
         .then(function (result) { return console.log(web3.eth.getTransaction(result)); });
 }
@@ -47,16 +47,16 @@ function spend(node) {
                 }
             });
         };
-        setTimeout(send, 10000);
+        setTimeout(send, 1000);
     })
         .then(function (result) { return console.log(web3.eth.getTransaction(result)); });
 }
 function doubleSpend(config) {
     var node1 = new _1.GethNode(config);
     var node2 = new _1.GethNode(config);
-    node1.start(8546).then(function () { return fund(node1); }).then(function () { return spend(node1); })
-        .then(function () { return _1.mine(node2, 8547, 19000).then(function () { return fund(node2); })
-        .then(function () { return node2.start(8546); }).then(function () { return spend(node2); }); });
+    _1.mine(node1, 8546, 30000).then(function () { return node1.start(8546).then(function () { return fund(node1); }).then(function () { return spend(node1); })
+        .then(function () { return _1.mine(node2, 8547, 30000).then(function () { return node2.start(8546); })
+        .then(function () { return fund(node2); }).then(function () { return spend(node2); }); }); });
 }
 exports.doubleSpend = doubleSpend;
 //# sourceMappingURL=double-spend.js.map

--- a/lab/double-spend.js
+++ b/lab/double-spend.js
@@ -4,14 +4,26 @@ var _1 = require("./");
 function fund(node) {
     var web3 = node.getWeb3();
     return new Promise(function (resolve, reject) {
-        console.log(web3.eth.getBalance(web3.eth.coinbase).toNumber(), "I AM THE COINBASE BALANCE");
-        web3.personal.unlockAccount(web3.eth.coinbase);
-        web3.eth.sendTransaction({
-            from: web3.eth.coinbase,
-            to: web3.eth.accounts[1],
-            value: web3.toWei(35)
-        }, function (err, tx) { resolve(tx); });
-    });
+        var send = function () {
+            web3.personal.unlockAccount(web3.eth.coinbase);
+            web3.eth.sendTransaction({
+                from: web3.eth.coinbase,
+                to: web3.eth.accounts[1],
+                value: web3.toWei(35)
+            }, function (err, tx) {
+                if (err) {
+                    console.log(err);
+                    reject(err);
+                }
+                else {
+                    console.log(tx);
+                    resolve(tx);
+                }
+            });
+        };
+        setTimeout(fund, 10000);
+    })
+        .then(function (result) { return console.log(web3.eth.getTransaction(result)); });
 }
 function spend(node) {
     var web3 = node.getWeb3();

--- a/lab/double-spend.ts
+++ b/lab/double-spend.ts
@@ -5,12 +5,13 @@ import {GethNodeConfig} from "./geth-node";
 function fund(node: GethNode) {
   const web3 = node.getWeb3()
   return new Promise<void>((resolve, reject) => {
+    console.log(web3.eth.getBalance(web3.eth.coinbase), "coinbase balance")
     const send = () => {
       web3.personal.unlockAccount(web3.eth.coinbase)
       web3.eth.sendTransaction({
         from: web3.eth.coinbase,
         to: web3.eth.accounts[1],
-        value: web3.toWei(35)
+        value: web3.toWei(8)
       }, function (err, tx) {
         if (err) {
           console.log(err)
@@ -22,7 +23,7 @@ function fund(node: GethNode) {
         }
       })
     }
-    setTimeout(fund, 10000)
+    setTimeout(send, 10000)
   })
     .then(result => console.log(web3.eth.getTransaction(result)))
 }
@@ -30,12 +31,13 @@ function fund(node: GethNode) {
 function spend(node: GethNode) {
   const web3 = node.getWeb3()
   return new Promise<void>((resolve, reject) => {
+    console.log(web3.eth.getBalance(web3.eth.accounts[1]), "account 1 balance")
     const send = () => {
       web3.personal.unlockAccount(web3.eth.accounts[1])
       web3.eth.sendTransaction({
         from: web3.eth.accounts[1],
         to: web3.eth.accounts[2],
-        value: web3.toWei(18)
+        value: web3.toWei(5)
       }, function (err, tx) {
         if (err) {
           console.log(err)

--- a/lab/double-spend.ts
+++ b/lab/double-spend.ts
@@ -28,9 +28,10 @@ function fund(node: GethNode) {
     .then(result => console.log(web3.eth.getTransaction(result)))
 }
 
-function spend(node: GethNode) {
+function spend(node: GethNode, miner?: GethNode) {
   const web3 = node.getWeb3()
   return new Promise<void>((resolve, reject) => {
+    mine(miner, 8547, 30000)
     const send = () => {
       console.log(web3.eth.getBalance(web3.eth.accounts[1]), "account 1 balance")
       web3.personal.unlockAccount(web3.eth.accounts[1])
@@ -57,7 +58,7 @@ function spend(node: GethNode) {
 export function doubleSpend(config?: GethNodeConfig) {
   const node1 = new GethNode(config)
   const node2 = new GethNode(config)
-    mine(node1, 8546, 30000).then(() => node1.start(8546).then(() => fund(node1)).then(() => spend(node1))
-      .then(() => mine(node2, 8547, 30000).then(() => node2.start(8546))
+    mine(node1, 8546, 30000).then(() => node1.start(8546).then(() => fund(node1)).then(() => spend(node1, node2))
+      .then(() => node2.start(8546))
       .then(() => fund(node2)).then(() => spend(node2))) 
 }

--- a/lab/double-spend.ts
+++ b/lab/double-spend.ts
@@ -31,8 +31,8 @@ function fund(node: GethNode) {
 function spend(node: GethNode) {
   const web3 = node.getWeb3()
   return new Promise<void>((resolve, reject) => {
-    console.log(web3.eth.getBalance(web3.eth.accounts[1]), "account 1 balance")
     const send = () => {
+      console.log(web3.eth.getBalance(web3.eth.accounts[1]), "account 1 balance")
       web3.personal.unlockAccount(web3.eth.accounts[1])
       web3.eth.sendTransaction({
         from: web3.eth.accounts[1],
@@ -49,7 +49,7 @@ function spend(node: GethNode) {
         }
       })
     }
-    setTimeout(send, 1000)
+    setTimeout(send, 15000)
   })
     .then(result => console.log(web3.eth.getTransaction(result)))
 }

--- a/lab/double-spend.ts
+++ b/lab/double-spend.ts
@@ -2,8 +2,8 @@ import {GethNode, mine} from "./"
 import {GethNodeConfig} from "./geth-node";
 
 
-function fund(client) {
-    const web3 = client
+function fund(node: GethNode) {
+    const web3 = node.getWeb3()
     return new Promise<void>((resolve, reject) => {
      console.log(web3.eth.getBalance(web3.eth.coinbase).toNumber(), "I AM THE COINBASE BALANCE")
       web3.personal.unlockAccount(web3.eth.coinbase)
@@ -17,7 +17,6 @@ function fund(client) {
 
 function spend(node: GethNode) {
   const web3 = node.getWeb3()
-  fund(web3).then(() => {
   return new Promise<void>((resolve, reject) => {
     const send = () => {
       web3.personal.unlockAccount(web3.eth.accounts[1])
@@ -39,12 +38,12 @@ function spend(node: GethNode) {
     setTimeout(send, 10000)
   })
     .then(result => console.log(web3.eth.getTransaction(result)))
-  })
 }
 
 export function doubleSpend(config?: GethNodeConfig) {
   const node1 = new GethNode(config)
   const node2 = new GethNode(config)
-    node1.start(8546).then(() => spend(node1))
-      .then(() => mine(node2, 8547, 9000).then(() => node2.start(8546)).then(() => spend(node2))) 
+    node1.start(8546).then(() => fund(node1)).then(() => spend(node1))
+      .then(() => mine(node2, 8547, 19000).then(() => fund(node2))
+      .then(() => node2.start(8546)).then(() => spend(node2))) 
 }

--- a/lab/double-spend.ts
+++ b/lab/double-spend.ts
@@ -3,17 +3,29 @@ import {GethNodeConfig} from "./geth-node";
 
 
 function fund(node: GethNode) {
-    const web3 = node.getWeb3()
-    return new Promise<void>((resolve, reject) => {
-     console.log(web3.eth.getBalance(web3.eth.coinbase).toNumber(), "I AM THE COINBASE BALANCE")
+  const web3 = node.getWeb3()
+  return new Promise<void>((resolve, reject) => {
+    const send = () => {
       web3.personal.unlockAccount(web3.eth.coinbase)
       web3.eth.sendTransaction({
         from: web3.eth.coinbase,
         to: web3.eth.accounts[1],
         value: web3.toWei(35)
-      }, function (err, tx) {resolve (tx)})
-    })
-} 
+      }, function (err, tx) {
+        if (err) {
+          console.log(err)
+          reject(err)
+        }
+        else {
+          console.log(tx)
+          resolve(tx)
+        }
+      })
+    }
+    setTimeout(fund, 10000)
+  })
+    .then(result => console.log(web3.eth.getTransaction(result)))
+}
 
 function spend(node: GethNode) {
   const web3 = node.getWeb3()

--- a/lab/double-spend.ts
+++ b/lab/double-spend.ts
@@ -23,7 +23,7 @@ function fund(node: GethNode) {
         }
       })
     }
-    setTimeout(send, 10000)
+    setTimeout(send, 1000)
   })
     .then(result => console.log(web3.eth.getTransaction(result)))
 }
@@ -49,7 +49,7 @@ function spend(node: GethNode) {
         }
       })
     }
-    setTimeout(send, 10000)
+    setTimeout(send, 1000)
   })
     .then(result => console.log(web3.eth.getTransaction(result)))
 }
@@ -57,7 +57,7 @@ function spend(node: GethNode) {
 export function doubleSpend(config?: GethNodeConfig) {
   const node1 = new GethNode(config)
   const node2 = new GethNode(config)
-    node1.start(8546).then(() => fund(node1)).then(() => spend(node1))
-      .then(() => mine(node2, 8547, 19000).then(() => fund(node2))
-      .then(() => node2.start(8546)).then(() => spend(node2))) 
+    mine(node1, 8546, 30000).then(() => node1.start(8546).then(() => fund(node1)).then(() => spend(node1))
+      .then(() => mine(node2, 8547, 30000).then(() => node2.start(8546))
+      .then(() => fund(node2)).then(() => spend(node2))) 
 }


### PR DESCRIPTION
@silentorb 

This is a pretty good outline for how this should work. Its hard to fund eth.accounts[1] from an etherbase, I added mining in all the places hoping that the account balance of eth.accounts[1] would show that it received Eth from the eth.coinbase. Without that distribution its hard to do this the way that I want to where I try to send 5 Eth, twice, from an account that only has 8 Eth.